### PR TITLE
1.2.0

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -1028,7 +1028,7 @@ class Settings_Page {
 
 									<h5 style="margin-top: 30px;"><?php esc_html_e( 'Add to Cart Button Functionality', 'feed-them-gallery' ); ?></h5>
 
-									<?php $woo_options = get_option( 'ft_gallery_woo_add_to_cart' ) ? get_option( 'ft_gallery_woo_add_to_cart' ) : 0; ?>
+									<?php $woo_options = get_option( 'ft_gallery_woo_add_to_cart' ) ? get_option( 'ft_gallery_woo_add_to_cart' ) : 0;   // print_r($woo_options)?>
 
 									<label><input name="ft_gallery_woo_add_to_cart[ft_gallery_woo_options]" type="radio" value="prod_page" <?php checked( 'prod_page', $woo_options['ft_gallery_woo_options'] ); ?>> <strong><?php esc_html_e( '(Default)', 'feed-them-gallery' ); ?></strong> <?php esc_html_e( 'Take Customers to product page. (Doesn\'t add product to cart)', 'feed-them-gallery' ); ?>
 									</label>

--- a/feed-them-gallery.php
+++ b/feed-them-gallery.php
@@ -7,20 +7,20 @@
  * Plugin Name: Feed Them Gallery
  * Plugin URI: https://www.slickremix.com/
  * Description: Create Beautiful Responsive Galleries in Minutes. Choose the number of columns a loadmore button, popup and more! Sell your galleries or individual images, watermark them and even zip galleries with our premium version.
- * Version: 1.1.9
+ * Version: 1.2.0
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-gallery
  * Domain Path: /languages
  * Requires at least: WordPress 4.7.0
  * Tested up to: WordPress 5.2.2
- * Stable tag: 1.1.9
+ * Stable tag: 1.2.0
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * WC requires at least: 3.0.0
  * WC tested up to: 3.6.5
  *
- * @version  1.1.9
+ * @version  1.2.0
  * @package  FeedThemSocial/Core
  * @copyright   Copyright (c) 2012-2019 SlickRemix
  *
@@ -28,7 +28,7 @@
  */
 
 // Doing this ensure's any js or css changes are reloaded properly. Added to enqued css and js files throughout.
-define( 'FTG_CURRENT_VERSION', '1.1.9' );
+define( 'FTG_CURRENT_VERSION', '1.2.0' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/includes/display-gallery/display-gallery-class.php
+++ b/includes/display-gallery/display-gallery-class.php
@@ -2041,7 +2041,9 @@ class Display_Gallery {
                                 <?php
                             }
 
-                            if ( isset( $ftg['is_album'] ) && 'yes' !== $ftg['is_album'] && !isset( $_GET['ftg-tags'] ) && 'page' !== $_GET['type'] || isset( $_GET['ftg-tags'] ) && 'page' !== $_GET['type'] ) {
+                            $my_get = stripslashes_deep( $_GET );
+                            $my_get['type'] = isset( $my_get['type'] ) ? $my_get['type'] : '';
+                            if ( isset( $ftg['is_album'] ) && 'yes' !== $ftg['is_album'] && !isset( $my_get['ftg-tags'], $my_get['type'] ) && 'page' !== $my_get['type'] || isset( $my_get['ftg-tags'], $my_get['type'] ) && 'page' !== $my_get['type'] ) {
 
                                 if ( 'yes' !== $hide_add_to_cart ) {
 
@@ -2093,7 +2095,7 @@ class Display_Gallery {
 
                                                 $ft_gallery_cart_page_name = get_option( 'ft_gallery_cart_page_name' ) ? get_option( 'ft_gallery_cart_page_name' ) : 'cart';
 
-                                                if ( 'variable' === $product->get_type( 'variable' ) ) {
+                                                if ( 'variable' === $product->get_type( 'variable' ) && 'prod_page' !== $purchase_link_option ) {
                                                     $purchase_link = '' . $siteurl . '/' . $ft_gallery_cart_page_name;
                                                 } else {
                                                     if ( 'prod_page' === $purchase_link_option ) {
@@ -2176,7 +2178,7 @@ class Display_Gallery {
 
                                 $ft_gallery_cart_page_name = get_option( 'ft_gallery_cart_page_name' ) ? get_option( 'ft_gallery_cart_page_name' ) : 'cart';
 
-                                if ( 'variable' === $product->get_type( 'variable' ) ) {
+                                if ( 'variable' === $product->get_type( 'variable' ) && 'prod_page' !== $purchase_link_option ) {
                                     $purchase_link = '' . $siteurl . '/' . $ft_gallery_cart_page_name;
                                 } else {
                                     if ( 'prod_page' === $purchase_link_option ) {
@@ -2367,7 +2369,7 @@ class Display_Gallery {
 
                                         $ft_gallery_cart_page_name = get_option( 'ft_gallery_cart_page_name' ) ? get_option( 'ft_gallery_cart_page_name' ) : 'cart';
 
-                                        if ( 'variable' === $product->get_type( 'variable' ) ) {
+                                        if ( 'variable' === $product->get_type( 'variable' ) && 'prod_page' !== $purchase_link_option ) {
                                             $purchase_link = '' . $siteurl . '/' . $ft_gallery_cart_page_name;
                                         } else {
                                             if ( 'prod_page' === $purchase_link_option ) {

--- a/readme.txt
+++ b/readme.txt
@@ -126,6 +126,10 @@ See [Full Documentation](https://www.slickremix.com/feed-them-gallery/)
   * Extract the zip file and drop the contents in the wp-content/plugins/ directory of your WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
+= Version 1.2.0 Monday, July 8th, 2019 =
+   * FIX: Settings: Take user to product option not working if your product was a variable.
+   * PREMIUM NEW: Tags Page: Added WooCommerce Add to cart options so you can make your tags page look similar to your gallery if you want.
+
 = Version 1.1.9 Wednesday, July 3rd, 2019 =
    * NEW: Security Refactor of the whole plugin to stop XSS injections and other possibly malicious attempts to hack through the plugin.
    * NEW: Layout Tab: Show the image caption info above or below the photos.


### PR DESCRIPTION
= Version 1.2.0 Monday, July 8th, 2019 =
   * FIX: Settings: Take user to product option not working if your product was a variable.
   * PREMIUM NEW: Tags Page: Added WooCommerce Add to cart options so you can make your tags page look similar to your gallery if you want.