### PR TITLE
1.2.9

### DIFF
--- a/feed-them-gallery.php
+++ b/feed-them-gallery.php
@@ -7,20 +7,20 @@
  * Plugin Name: Feed Them Gallery
  * Plugin URI: https://www.slickremix.com/
  * Description: Create Beautiful Responsive Galleries in Minutes. Choose the number of columns, loadmore button, popup and more! Sell your Galleries or individual Images with WooCommerce, watermark them, zip galleries, create Albums, create Tags for Images and Galleries, search Galleries and Images with tags, and pagination in our premium version.
- * Version: 1.2.8
+ * Version: 1.2.9
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-gallery
  * Domain Path: /languages
  * Requires at least: WordPress 4.7.0
- * Tested up to: WordPress 5.3.2
- * Stable tag: 1.2.8
+ * Tested up to: WordPress 5.4.2
+ * Stable tag: 1.2.9
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * WC requires at least: 3.0.0
- * WC tested up to: 3.9.1
+ * WC tested up to: 4.1.1
  *
- * @version  1.2.8
+ * @version  1.2.9
  * @package  FeedThemSocial/Core
  * @copyright   Copyright (c) 2012-2020 SlickRemix
  *
@@ -28,7 +28,7 @@
  */
 
 // Doing this ensure's any js or css changes are reloaded properly. Added to enqued css and js files throughout.
-define( 'FTG_CURRENT_VERSION', '1.2.8' );
+define( 'FTG_CURRENT_VERSION', '1.2.9' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/includes/js/zip-full.js
+++ b/includes/js/zip-full.js
@@ -60,6 +60,7 @@ function ft_gallery_create_zip(postID, activate_download, create_woo_prod, downl
                 window.location.assign(data);
             }
             else if(activate_download !== 'yes' && download_newest_zip !== 'yes' && create_woo_prod == 'yes'){
+                // need to address the fact that the this link does not bring back the proper zip tab to show... ' + window.location.href + '&tab=ft_zip_gallery
                 jQuery('.ft-gallery-notice').html('ZIP Created! You can view it in the <a href="' + window.location.href + '&tab=ft_zip_gallery">ZIPs tab</a>. The Woocommerce product was also created you view it on the <a href="edit.php?post_status=publish&post_type=product&orderby=menu_order+title&order=ASC" target="_blank">Products Page</a>.');
                 jQuery('.ft-gallery-notice').prepend('<div class="fa fa-check-circle fa-3x fa-fw ft-gallery-success" ></div>');
                 jQuery('.ft-gallery-notice').addClass('updated');

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: slickremix, slickchris
 Tags: gallery, image gallery, photo gallery, responsive gallery, wordpress gallery plugin
 Requires at least: 4.5.0
-Tested up to: 5.3.2
-Stable tag: 1.2.8
+Tested up to: 5.4.2
+Stable tag: 1.2.9
 License: GPLv2 or later
 
 Photo Gallery creation made easy. Sell images with Auto Create Product feature for WooCommerce. Watermarking, Lightbox Popup, ZIP'ing, Tags and more!
@@ -160,6 +160,9 @@ See [Full Documentation](https://www.slickremix.com/feed-them-gallery/)
   * Extract the zip file and drop the contents in the wp-content/plugins/ directory of your WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
+= Version 1.2.9 Monday, June 1st, 2020 =
+   * NEW: Added languages folder to the root of plugin so those that want translate can.
+
 = Version 1.2.8 Wednesday, February 5th, 2020 =
    * FIX: CSS: Extra spacing on a few elements on the edit gallery page.
    * PREMIUM FIX: JS: Albums Watermark: Preview image was not appearing after the image was chosen.

--- a/readme.txt
+++ b/readme.txt
@@ -151,6 +151,9 @@ FREE PLUGIN OPTIONS
 
 See [Full Documentation](https://www.slickremix.com/feed-them-gallery/)
 
+= Translate Plugin =
+You can [register to translate the site here](http://translate.slickremix.com/wp-login.php?action=register), then [click here to translate the plugin](http://translate.slickremix.com/glotpress/projects/feed-them-gallery/) and download your translation files right away. Add the files to the languages folder in the root of our plugin. After that just make sure you have chosen the correct language in the WordPress Settings area.
+
 == Installation ==
 
 = Install from WordPress Dashboard =
@@ -161,7 +164,7 @@ See [Full Documentation](https://www.slickremix.com/feed-them-gallery/)
 
 == Changelog ==
 = Version 1.2.9 Monday, June 1st, 2020 =
-   * NEW: Added languages folder to the root of plugin so those that want translate can.
+   * NEW: Added languages folder to the root of plugin for those who want to add a translation files. You can [register to translate the site here](http://translate.slickremix.com/wp-login.php?action=register), then go to this link to [translate the plugin](http://translate.slickremix.com/glotpress/projects/feed-them-gallery/) and download your translation files right away.
 
 = Version 1.2.8 Wednesday, February 5th, 2020 =
    * FIX: CSS: Extra spacing on a few elements on the edit gallery page.
@@ -172,7 +175,7 @@ See [Full Documentation](https://www.slickremix.com/feed-them-gallery/)
 
 = Version 1.2.6 Tuesday, November 19th, 2019 =
    * TESTED: WordPress 5.3.0 compatibility tested. No issues currently found.
-   * ADD: SlickChris as a plugin contributer to .org repo.
+   * ADD: SlickChris as a plugin contributor to .org repo.
    
 = Version 1.2.5.1 Wednesday, October 16th, 2019 =
    * UPDATE: Add New Promo video to the ReadMe.


### PR DESCRIPTION
= Version 1.2.9 Monday, June 1st, 2020 =
   * NEW: Added languages folder to the root of plugin for those who want to add a translation files. You can [register to translate the site here](http://translate.slickremix.com/wp-login.php?action=register), then go to this link to [translate the plugin](http://translate.slickremix.com/glotpress/projects/feed-them-gallery/) and download your translation files right away.