### PR TITLE
1.2.9

### DIFF
--- a/feed-them-gallery.php
+++ b/feed-them-gallery.php
@@ -7,20 +7,20 @@
  * Plugin Name: Feed Them Gallery
  * Plugin URI: https://www.slickremix.com/
  * Description: Create Beautiful Responsive Galleries in Minutes. Choose the number of columns, loadmore button, popup and more! Sell your Galleries or individual Images with WooCommerce, watermark them, zip galleries, create Albums, create Tags for Images and Galleries, search Galleries and Images with tags, and pagination in our premium version.
- * Version: 1.2.9
+ * Version: 1.2.9.1
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-gallery
  * Domain Path: /languages
  * Requires at least: WordPress 4.7.0
  * Tested up to: WordPress 5.4.2
- * Stable tag: 1.2.9
+ * Stable tag: 1.2.9.1
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * WC requires at least: 3.0.0
  * WC tested up to: 4.1.1
  *
- * @version  1.2.9
+ * @version  1.2.9.1
  * @package  FeedThemSocial/Core
  * @copyright   Copyright (c) 2012-2020 SlickRemix
  *
@@ -28,7 +28,7 @@
  */
 
 // Doing this ensure's any js or css changes are reloaded properly. Added to enqued css and js files throughout.
-define( 'FTG_CURRENT_VERSION', '1.2.9' );
+define( 'FTG_CURRENT_VERSION', '1.2.9.1' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/includes/display-gallery/display-gallery-class.php
+++ b/includes/display-gallery/display-gallery-class.php
@@ -3026,5 +3026,3 @@ class Display_Gallery {
         <?php }
     }
 }
-
-?>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris
 Tags: gallery, image gallery, photo gallery, responsive gallery, wordpress gallery plugin
 Requires at least: 4.5.0
 Tested up to: 5.4.2
-Stable tag: 1.2.9
+Stable tag: 1.2.9.1
 License: GPLv2 or later
 
 Photo Gallery creation made easy. Sell images with Auto Create Product feature for WooCommerce. Watermarking, Lightbox Popup, ZIP'ing, Tags and more!
@@ -163,6 +163,9 @@ You can [register to translate the site here](http://translate.slickremix.com/wp
   * Extract the zip file and drop the contents in the wp-content/plugins/ directory of your WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
+= Version 1.2.9.1 Tuesday, June 2nd, 2020 =
+   * FIX: Remove closing php bracket at the end of the metabox-settings-class.php file as it was causing headers already sent message for some servers.
+
 = Version 1.2.9 Monday, June 1st, 2020 =
    * NEW: Added languages/feed-them-gallery.pot file to the root of plugin for those who want to add a translation files. You can [register to translate the site here](http://translate.slickremix.com/wp-login.php?action=register), then go to this link to [translate the plugin](http://translate.slickremix.com/glotpress/projects/feed-them-gallery/) and download your translation files right away.
 


### PR DESCRIPTION
= Version 1.2.9.1 Tuesday, June 2nd, 2020 =
   * FIX: Remove closing php bracket at the end of the metabox-settings-class.php file as it was causing headers already sent message for some servers.