### PR TITLE
1.3.3

### DIFF
--- a/feed-them-gallery.php
+++ b/feed-them-gallery.php
@@ -7,20 +7,20 @@
  * Plugin Name: Feed Them Gallery
  * Plugin URI: https://www.slickremix.com/
  * Description: Create Beautiful Responsive Galleries in Minutes. Choose the number of columns, loadmore button, popup and more! Sell your Galleries or individual Images with WooCommerce, watermark them, zip galleries, create Albums, create Tags for Images and Galleries, search Galleries and Images with tags, and pagination in our premium version.
- * Version: 1.3.2
+ * Version: 1.3.3
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-gallery
  * Domain Path: /languages
  * Requires at least: WordPress 4.7.0
  * Tested up to: WordPress 5.5
- * Stable tag: 1.3.2
+ * Stable tag: 1.3.3
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * WC requires at least: 3.0.0
- * WC tested up to: 4.3.3
+ * WC tested up to: 4.4.1
  *
- * @version  1.3.2
+ * @version  1.3.3
  * @package  FeedThemSocial/Core
  * @copyright   Copyright (c) 2012-2020 SlickRemix
  *
@@ -28,7 +28,7 @@
  */
 
 // Doing this ensure's any js or css changes are reloaded properly. Added to enqued css and js files throughout.
-define( 'FTG_CURRENT_VERSION', '1.3.2' );
+define( 'FTG_CURRENT_VERSION', '1.3.3' );
 
 // Require file for plugin loading.
 require_once __DIR__ . '/class-load-plugin.php';

--- a/feed-them-gallery.php
+++ b/feed-them-gallery.php
@@ -27,7 +27,7 @@
  * Need Support? https://www.slickremix.com/my-account
  */
 
-// Doing this ensure's any js or css changes are reloaded properly. Added to enqued css and js files throughout.
+// Doing this to ensure any js or css changes are reloaded properly. Added to enqued css and js files throughout.
 define( 'FTG_CURRENT_VERSION', '1.3.3' );
 
 // Require file for plugin loading.

--- a/includes/display-gallery/display-gallery-class.php
+++ b/includes/display-gallery/display-gallery-class.php
@@ -24,7 +24,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Display_Gallery {
 
-
 	/**
 	 * Holds the base class object.
 	 *

--- a/includes/display-gallery/display-gallery-class.php
+++ b/includes/display-gallery/display-gallery-class.php
@@ -695,6 +695,7 @@ class Display_Gallery {
 
 			$total_pagination_count = $gallery_class->ft_album_count_post_galleries( $ftg_id );
 			$pagination_text        = esc_html( 'Galleries', 'feed-them-gallery' );
+            $pagination_query_var   = 'paged';
 
 		} elseif ( isset( $tags ) && 'yes' === $tags ) {
 
@@ -704,22 +705,24 @@ class Display_Gallery {
 			$total_pagination_count = $image_count_for_tags;
 			$ftg_tags               = sanitize_text_field( wp_unslash( $my_get[ $taxonomy ] ) );
 			$pagination_text        = isset( $ftg_tags ) && 'page' === $ftg_tags ? esc_html( 'Galleries', 'feed-them-gallery' ) : esc_html( 'Images', 'feed-them-gallery' );
+			$pagination_query_var   = 'page';
 
 		} else {
 			$total_pagination_count = $gallery_class->ft_gallery_count_post_images( $ftg_id );
 			$pagination_text        = esc_html( 'Images', 'feed-them-gallery' );
+            $pagination_query_var   = 'paged';
 		}
 
 		$check_total_pagination_count = ceil( esc_html( $total_pagination_count ) / esc_html( $per_page ) );
 
-		if ( $check_total_pagination_count <= get_query_var( 'page' ) ) {
+		if ( $check_total_pagination_count <= get_query_var( $pagination_query_var ) ) {
 			// This is the final count number, meaning the last page of pagination.
-			$count_fix      = get_query_var( 'page' ) - '1';
+			$count_fix      = get_query_var( $pagination_query_var ) - '1';
 			$per_page_final = $per_page * $count_fix + 1;
 			$count_per_page = $total_pagination_count;
-		} elseif ( '1' < get_query_var( 'page' ) ) {
+		} elseif ( '1' < get_query_var( $pagination_query_var ) ) {
 			// This is any other number that 1 or the last page.
-			$count_per_page = min( $total_pagination_count, $per_page * get_query_var( 'page' ) );
+			$count_per_page = min( $total_pagination_count, $per_page * get_query_var( $pagination_query_var ) );
 			$per_page_final = $count_per_page - $per_page + 1;
 		} else {
 			// This is only for the 1st page.
@@ -763,9 +766,9 @@ class Display_Gallery {
 
 		$pagination_counts = paginate_links(
 			array(
-				'base'      => add_query_arg( 'page', '%#%' ),
-				'format'    => '?page=%#%',
-				'current'   => max( 1, get_query_var( 'page' ) ),
+				'base'      => add_query_arg( $pagination_query_var, '%#%' ),
+				'format'    => "?'.$pagination_query_var.'=%#%",
+				'current'   => max( 1, get_query_var( $pagination_query_var ) ),
 				'mid_size'  => 3,
 				'end_size'  => 3,
 				'prev_text' => __( '&#10094;' ),
@@ -1360,6 +1363,8 @@ class Display_Gallery {
 		$ftg_photo_count                   = null !== $option['ft_gallery_photo_count'] ? $option['ft_gallery_photo_count'] : '50';
 		$ft_gallery_show_true_pagination   = null !== $option['ft_gallery_show_true_pagination'] && 'yes' === $option['ft_gallery_show_true_pagination'] ? $option['ft_gallery_show_true_pagination'] : '';
 
+        $pagination_query_var   = isset( $_GET['ftg-tags'] ) ? 'page' : 'paged';
+
 		if ( isset( $ftg['is_album'] ) && 'yes' === $ftg['is_album'] || isset( $_GET['ftg-tags'] ) && 'page' === $_GET['type'] ) {
 
 			$orderby_set = '' !== $option['ftg_sort_type'] ? $option['ftg_sort_type'] : 'date';
@@ -1372,7 +1377,7 @@ class Display_Gallery {
 
 			$count_per_page = $post_count;
 			if ( 'yes' === $ft_gallery_show_true_pagination || ! empty( $_GET['ftg-tags'] ) ) {
-				$paged = get_query_var( 'page' ) ? get_query_var( 'page' ) : 1;
+				$paged = get_query_var( $pagination_query_var ) ? get_query_var( $pagination_query_var ) : 1;
 				// After that, calculate the offset.
 				$offset = ( $paged - 1 ) * $count_per_page;
 			} else {
@@ -1444,7 +1449,7 @@ class Display_Gallery {
 			// $getpost_attr['paged'] = esc_html( $paged );
 			// echo '<pre>';
 			// print_r($getpost_attr);
-			// echo '</pre>';
+			// echo '</pre>';s
 			// echo '<pre>';
 			// print_r($image_list);
 			// echo '</pre>'; .
@@ -1459,7 +1464,7 @@ class Display_Gallery {
 			}
 
 			if ( 'yes' === $ft_gallery_show_true_pagination ) {
-				$paged  = get_query_var( 'page' ) ? get_query_var( 'page' ) : 1;
+				$paged  = get_query_var( $pagination_query_var ) ? get_query_var( $pagination_query_var ) : 1;
 				$offset = ( $paged - 1 ) * $post_count;
 			} else {
 				$paged  = $ftg['offset'];

--- a/readme.txt
+++ b/readme.txt
@@ -166,7 +166,7 @@ You can [register to translate the site here](http://translate.slickremix.com/wp
 
 == Changelog ==
 = Version 1.3.3 Wednesday, August 26th, 2020 =
-   * FIX: Pagination not working on the front end after latest change in WordPress 5.5
+   * FIX: Pagination not working on the front end after WordPress 5.5 update
    * UPDATED: Works with WooCommerce vs 4.4.1
 
 = Version 1.3.2 Monday, August 17th, 2020 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris
 Tags: gallery, image gallery, photo gallery, responsive gallery, wordpress gallery plugin
 Requires at least: 4.5.0
 Tested up to: 5.5
-Stable tag: 1.3.2
+Stable tag: 1.3.3
 License: GPLv2 or later
 
 Photo Gallery creation made easy. Sell images with Auto Create Product feature for WooCommerce. Watermarking, Lightbox Popup, ZIP'ing, Tags and more!
@@ -165,6 +165,10 @@ You can [register to translate the site here](http://translate.slickremix.com/wp
   * Extract the zip file and drop the contents in the wp-content/plugins/ directory of your WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
+= Version 1.3.3 Wednesday, August 26th, 2020 =
+   * FIX: Pagination not working on the front end after latest change in WordPress 5.5
+   * UPDATED: Works with WooCommerce vs 4.4.1
+
 = Version 1.3.2 Monday, August 17th, 2020 =
    * MAJOR FIX: Make compatible with WordPress 5.5 update. (There is still a [bug](https://core.trac.wordpress.org/ticket/50976#comment:7) with pagination on the front end but this is a core issue we hope will be resolved in the next week)
    * FIX: Check for hasClass ftg-premium-not-active so we don't run a load tags js function causing js error in popup if premium is not active.


### PR DESCRIPTION
= Version 1.3.3 Wednesday, August 26th, 2020 =
   * FIX: Pagination not working on the front end after WordPress 5.5 update
   * UPDATED: Works with WooCommerce vs 4.4.1