### PR TITLE
1.3.7

### DIFF
--- a/.idea/deployment.xml
+++ b/.idea/deployment.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="PublishConfigData" serverName="FTG FREE devstage">
+  <component name="PublishConfigData" serverName="FTG Dev Staging">
     <serverData>
       <paths name="FTG Dev Staging">
         <serverdata>
           <mappings>
-            <mapping deploy="/" local="$PROJECT_DIR$" web="/" />
+            <mapping deploy="/wp-content/plugins/feed-them-gallery" local="$PROJECT_DIR$" web="/" />
           </mappings>
         </serverdata>
       </paths>

--- a/includes/galleries/gallery-class.php
+++ b/includes/galleries/gallery-class.php
@@ -108,7 +108,14 @@ class Gallery {
 
 		$this->saved_settings_array = $all_options;
 
-		if ( is_admin() ) {
+		// we set current_user_can so our backend functions don't get loaded to the front end.
+		// this came about after a ticket we received about our plugin being active and
+		// causing a woo booking plugin to not be able to checkout proper and ninja forms submit forms , when checking out it would show the cart was empty.
+		// this current_user_can resolves that problem.
+		if(!function_exists('wp_get_current_user')) {
+			include(ABSPATH . "wp-includes/pluggable.php");
+		}
+		if ( is_admin() && current_user_can( 'manage_options' ) ) {
 			// Load Metabox Setings Class (including all of the scripts and styles attached).
 			$this->metabox_settings_class = new Metabox_Settings( $this, $this->saved_settings_array );
 


### PR DESCRIPTION
Added

`// we set current_user_can so our backend functions don't get loaded to the front end.
		// this came about after a ticket we received about our plugin being active and
		// causing a woo booking plugin to not be able to checkout proper and ninja forms submit forms , when checking out it would show the cart was empty.
		// this current_user_can resolves that problem.
		if(!function_exists('wp_get_current_user')) {
			include(ABSPATH . "wp-includes/pluggable.php");
		}
		if ( is_admin() && current_user_can( 'manage_options' ) ) {....`

