### PR TITLE
1.3.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris, mikeyhoward1977
 Tags: gallery, image gallery, photo gallery, responsive gallery, wordpress gallery plugin
 Requires at least: 4.5.0
 Tested up to: 5.7
-Stable tag: 1.3.7
+Stable tag: 1.3.8
 License: GPLv2 or later
 
 Photo Gallery creation made easy. Sell images with Auto Create Product feature for WooCommerce. Watermarking, Lightbox Popup, ZIP'ing, Tags and more!


### PR DESCRIPTION
= Version 1.3.8 Thursday, March 25th, 2021 =
   * FIX: Add !wp_doing_ajax() around album class scripts so ajax is not accessible to the front end.
   * FIX: Gallery popup will display content on right side by default on screens larger than 1900px now instead of below.
   * FIX: Redirect ALL ftg custom posts option on settings page was required to make single gallery pages redirect, this was not necessary.