### PR TITLE
1.4.3

### DIFF
--- a/admin/settings/settings-functions.php
+++ b/admin/settings/settings-functions.php
@@ -201,7 +201,7 @@ function ftg_checkbox_callback( $args ) {
 
 	$checked = ! empty( $ftg_option ) ? checked( 1, $ftg_option, false ) : '';
 
-	$html  = '<input type="hidden"' . $name . ' value="-1" />';
+	$html  = '<input type="hidden"' . $name . ' value="" />';
 	$html .= '<input type="checkbox" id="ftg_settings[' . ftg_sanitize_key( $args['id'] ) . ']"' . $name . ' value="1" ' . $checked . ' class="' . $class . '"/>';
 	$html .= '<label for="ftg_settings[' . ftg_sanitize_key( $args['id'] ) . ']"> '  . wp_kses_post( $args['desc'] ) . '</label>';
 

--- a/feed-them-gallery.php
+++ b/feed-them-gallery.php
@@ -7,20 +7,20 @@
  * Plugin Name: Feed Them Gallery
  * Plugin URI: https://www.slickremix.com/
  * Description: Create Beautiful Responsive Galleries in Minutes. Choose the number of columns, loadmore button, popup and more! Sell your Galleries or individual Images with WooCommerce, watermark them, zip galleries, create Albums, create Tags for Images and Galleries, search Galleries and Images with tags, and pagination in our premium version.
- * Version: 1.4.2
+ * Version: 1.4.3
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-gallery
  * Domain Path: /languages
  * Requires at least: WordPress 4.7.0
- * Tested up to: WordPress 5.8.1
- * Stable tag: 1.4.2
+ * Tested up to: WordPress 5.8.2
+ * Stable tag: 1.4.3
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * WC requires at least: 3.0.0
- * WC tested up to: 5.8.0
+ * WC tested up to: 5.9.0
  *
- * @version  1.4.2
+ * @version  1.4.3
  * @package  FeedThemSocial/Core
  * @copyright   Copyright (c) 2012-2021 SlickRemix
  *
@@ -28,7 +28,7 @@
  */
 
 // Doing this to ensure any js or css changes are reloaded properly. Added to enqueued css and js files throughout.
-define( 'FTG_CURRENT_VERSION', '1.4.2' );
+define( 'FTG_CURRENT_VERSION', '1.4.3' );
 
 if ( ! defined( 'FTG_PLUGIN_FILE' ) )	{
 	define( 'FTG_PLUGIN_FILE', __FILE__ );

--- a/includes/galleries/gallery-class.php
+++ b/includes/galleries/gallery-class.php
@@ -183,7 +183,7 @@ class Gallery {
 		// Add the image name to the media library so we can get a clean version when showing thumbnail on the page for the first time!
 		add_filter( 'image_size_names_choose', array( $this, 'ft_gallery_custom_thumb_sizes' ) );
 
-		if ( ! ftg_get_option( 'duplicate_post_show' ) ) {
+		if ( !empty( ftg_get_option( 'duplicate_post_show' ) ) ) {
 
 			add_action( 'admin_action_ft_gallery_duplicate_post_as_draft', array( $this, 'ft_gallery_duplicate_post_as_draft' ) );
 			add_filter( 'page_row_actions', array( $this, 'ft_gallery_duplicate_post_link' ), 10, 2 );
@@ -1210,7 +1210,7 @@ class Gallery {
 					if ( isset( $_GET['images'] ) && '-1' !== $_GET['images'] ) {
 						// Here we get_option the amount of users we want to see per page based on the saved settings field.
 						?>
-						<div class="ftg-total-pagination-count"><?php echo esc_html__( 'Showing', 'feed-them-gallery' ); ?> <?php echo esc_html( $per_page_final ); ?>-<?php echo esc_html( $count_per_page ); ?> of <?php echo esc_html( $total_pagination_count ); ?> <?php echo esc_html( 'Images', 'feed-them-gallery' ); ?></div>
+						<div class="ftg-total-pagination-count"><?php echo esc_html__( 'Showing', 'feed-them-gallery' ); ?> <?php echo esc_html( $per_page_final ); ?>-<?php echo esc_html( $count_per_page ); ?> <?php echo esc_html__( 'of', 'feed-them-gallery' ); ?> <?php echo esc_html( $total_pagination_count ); ?> <?php echo esc_html( 'Images', 'feed-them-gallery' ); ?></div>
 						<?php
 					}
 					?>

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: slickremix, slickchris, mikeyhoward1977
 Tags: gallery, image gallery, photo gallery, responsive gallery, wordpress gallery plugin
 Requires at least: 4.5.0
-Tested up to: 5.8.1
-Stable tag: 1.4.2
+Tested up to: 5.8.2
+Stable tag: 1.4.3
 License: GPLv2 or later
 
 Photo Gallery creation made easy. Sell images with Auto Create Product feature for WooCommerce. Watermarking, Lightbox Popup, ZIP'ing, Tags and more!
@@ -185,6 +185,10 @@ You can [register to translate the site here](http://translate.slickremix.com/wp
   * Extract the zip file and drop the contents in the wp-content/plugins/ directory of your WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
+= Version 1.4.3 Wednesday, November 17th, 2021 =
+   * FIX: Settings Page options not working properly on front end.
+   * FIX: Translation string for the word 'of' for pagination has been added. .ie 1 of 4.
+   
 = Version 1.4.2 Friday, October 29th, 2021 =
    * FIX: Display-gallery-class: foreach loop warning being logged in error.log file.
    * FIX: Settings Page: Checkboxes not always unchecking or checking when saving the page.

--- a/readme.txt
+++ b/readme.txt
@@ -185,7 +185,9 @@ You can [register to translate the site here](http://translate.slickremix.com/wp
   * Extract the zip file and drop the contents in the wp-content/plugins/ directory of your WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
-= Version 1.4.3 Wednesday, November 17th, 2021 =
+= Version 1.4.3 Thursday, November 18th, 2021 =
+   * NOTE: Tested with WordPress Version 5.8.2
+   * NOTE: Tested with WooCommerce Version 5.9.0
    * FIX: Settings Page options not working properly on front end.
    * FIX: Translation string for the word 'of' for pagination has been added. .ie 1 of 4.
    


### PR DESCRIPTION
= Version 1.4.3 Thursday, November 18th, 2021 =
   * NOTE: Tested with WordPress Version 5.8.2
   * NOTE: Tested with WooCommerce Version 5.9.0
   * FIX: Settings Page options not working properly on front end.
   * FIX: Translation string for the word 'of' for pagination has been added. .ie 1 of 4.