### PR TITLE
1.4.3.1

### DIFF
--- a/feed-them-gallery.php
+++ b/feed-them-gallery.php
@@ -7,20 +7,20 @@
  * Plugin Name: Feed Them Gallery
  * Plugin URI: https://www.slickremix.com/
  * Description: Create Beautiful Responsive Galleries in Minutes. Choose the number of columns, loadmore button, popup and more! Sell your Galleries or individual Images with WooCommerce, watermark them, zip galleries, create Albums, create Tags for Images and Galleries, search Galleries and Images with tags, and pagination in our premium version.
- * Version: 1.4.3
+ * Version: 1.4.3.1
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-gallery
  * Domain Path: /languages
  * Requires at least: WordPress 4.7.0
  * Tested up to: WordPress 5.8.2
- * Stable tag: 1.4.3
+ * Stable tag: 1.4.3.1
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * WC requires at least: 3.0.0
  * WC tested up to: 5.9.0
  *
- * @version  1.4.3
+ * @version  1.4.3.1
  * @package  FeedThemSocial/Core
  * @copyright   Copyright (c) 2012-2021 SlickRemix
  *
@@ -28,7 +28,7 @@
  */
 
 // Doing this to ensure any js or css changes are reloaded properly. Added to enqueued css and js files throughout.
-define( 'FTG_CURRENT_VERSION', '1.4.3' );
+define( 'FTG_CURRENT_VERSION', '1.4.3.1' );
 
 if ( ! defined( 'FTG_PLUGIN_FILE' ) )	{
 	define( 'FTG_PLUGIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris, mikeyhoward1977
 Tags: gallery, image gallery, photo gallery, responsive gallery, wordpress gallery plugin
 Requires at least: 4.5.0
 Tested up to: 5.8.2
-Stable tag: 1.4.3
+Stable tag: 1.4.3.1
 License: GPLv2 or later
 
 Photo Gallery creation made easy. Sell images with Auto Create Product feature for WooCommerce. Watermarking, Lightbox Popup, ZIP'ing, Tags and more!
@@ -185,6 +185,9 @@ You can [register to translate the site here](http://translate.slickremix.com/wp
   * Extract the zip file and drop the contents in the wp-content/plugins/ directory of your WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
+= Version 1.4.3.1 Tuesday, November 23rd, 2021 =
+   * FIX: Missing s for a sprint_f on plugin license page.
+   
 = Version 1.4.3 Thursday, November 18th, 2021 =
    * NOTE: Tested with WordPress Version 5.8.2
    * NOTE: Tested with WooCommerce Version 5.9.0

--- a/updater/updater-license-page.php
+++ b/updater/updater-license-page.php
@@ -185,7 +185,7 @@ class updater_license_page {
                        ); ?>
                     </li>
                     <li><?php
-                        echo sprintf(__('Now Enter your License Key and Click the %1$Save Changes button%2$s', 'feed-them-gallery'),
+                        echo sprintf(__('Now Enter your License Key and Click the %1$sSave Changes button%2$s', 'feed-them-gallery'),
                             '<strong>',
                             '</strong>'
                         ); ?>


### PR DESCRIPTION
= Version 1.4.3.1 Tuesday, November 23rd, 2021 =
   * FIX: Missing s for a sprint_f on plugin license page.