### PR TITLE
1.4.3.2

### DIFF
--- a/feed-them-gallery.php
+++ b/feed-them-gallery.php
@@ -13,12 +13,12 @@
  * Text Domain: feed-them-gallery
  * Domain Path: /languages
  * Requires at least: WordPress 4.7.0
- * Tested up to: WordPress 5.8.2
+ * Tested up to: WordPress 6.0
  * Stable tag: 1.4.3.2
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * WC requires at least: 3.0.0
- * WC tested up to: 6.1.1
+ * WC tested up to: 6.5.1
  *
  * @version  1.4.3.2
  * @package  FeedThemSocial/Core

--- a/readme.txt
+++ b/readme.txt
@@ -185,7 +185,7 @@ You can [register to translate the site here](http://translate.slickremix.com/wp
   * Extract the zip file and drop the contents in the wp-content/plugins/ directory of your WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
-= Version 1.4.3.2 Monday, June 9th, 2022 =
+= Version 1.4.3.2 Saturday, June 11th, 2022 =
   * NOTE: Tested with WordPress Version 6.0
   * FIX PREMIUM: Script not loading properly for variations on some sites.
   


### PR DESCRIPTION
= Version 1.4.3.2 Saturday, June 11th, 2022 =
  * NOTE: Tested with WordPress Version 6.0
  * FIX PREMIUM: Script not loading properly for variations on some sites.