### PR TITLE
1.4.5

### DIFF
--- a/.idea/deployment.xml
+++ b/.idea/deployment.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="PublishConfigData" serverName="FTG Dev Staging">
+  <component name="PublishConfigData" serverName="FTG FREE devstage">
     <serverData>
       <paths name="FTG Dev Staging">
         <serverdata>
           <mappings>
-            <mapping deploy="/wp-content/plugins/feed-them-gallery" local="$PROJECT_DIR$" web="/" />
+            <mapping deploy="/" local="$PROJECT_DIR$" web="/" />
           </mappings>
         </serverdata>
       </paths>
       <paths name="FTG FREE devstage">
         <serverdata>
           <mappings>
-            <mapping deploy="/wp-content/plugins/feed-them-gallery" local="$PROJECT_DIR$" web="/" />
+            <mapping deploy="/" local="$PROJECT_DIR$" web="/" />
           </mappings>
         </serverdata>
       </paths>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -5,4 +5,5 @@
       <PhpCSConfiguration tool_path="/usr/local/bin/phpcs" />
     </phpcs_settings>
   </component>
+  <component name="PhpProjectSharedConfiguration" php_language_level="7" />
 </project>

--- a/feed-them-gallery.php
+++ b/feed-them-gallery.php
@@ -7,20 +7,20 @@
  * Plugin Name: Feed Them Gallery
  * Plugin URI: https://www.slickremix.com/
  * Description: Create Beautiful Responsive Galleries in Minutes. Choose the number of columns, loadmore button, popup and more! Sell your Galleries or individual Images with WooCommerce, watermark them, zip galleries, create Albums, create Tags for Images and Galleries, search Galleries and Images with tags, and pagination in our premium version.
- * Version: 1.4.4
+ * Version: 1.4.5
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-gallery
  * Domain Path: /languages
  * Requires at least: WordPress 4.7.0
  * Tested up to: WordPress 6.0
- * Stable tag: 1.4.4
+ * Stable tag: 1.4.5
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * WC requires at least: 3.0.0
- * WC tested up to: 6.5.1
+ * WC tested up to: 6.6.1
  *
- * @version  1.4.4
+ * @version  1.4.5
  * @package  FeedThemSocial/Core
  * @copyright   Copyright (c) 2012-2022 SlickRemix
  *
@@ -28,7 +28,7 @@
  */
 
 // Doing this to ensure any js or css changes are reloaded properly. Added to enqueued css and js files throughout.
-define( 'FTG_CURRENT_VERSION', '1.4.4' );
+define( 'FTG_CURRENT_VERSION', '1.4.5' );
 
 if ( ! defined( 'FTG_PLUGIN_FILE' ) )	{
 	define( 'FTG_PLUGIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris, mikeyhoward1977
 Tags: gallery, image gallery, photo gallery, responsive gallery, wordpress gallery plugin
 Requires at least: 4.5.0
 Tested up to: 6.0
-Stable tag: 1.4.4
+Stable tag: 1.4.5
 License: GPLv2 or later
 
 Photo Gallery creation made easy. Sell images with Auto Create Product feature for WooCommerce. Watermarking, Lightbox Popup, ZIP'ing, Tags and more!
@@ -185,6 +185,10 @@ You can [register to translate the site here](http://translate.slickremix.com/wp
   * Extract the zip file and drop the contents in the wp-content/plugins/ directory of your WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
+= Version 1.4.5 Thursday, June 23rd, 2022 =
+  * NOTE: Tested with WocCommerce Version 6.6.1
+  * FIX PREMIUM: Url in tags select missing / to account for sub-site installs.
+  
 = Version 1.4.4 Saturday, June 11th, 2022 =
   * NOTE: Tested with WordPress Version 6.0
   * FIX PREMIUM: Script not loading properly for variations on some sites.

--- a/templates/archive-ftg-tags.php
+++ b/templates/archive-ftg-tags.php
@@ -51,7 +51,7 @@ $image_or_gallery = isset( $_GET['ftg-tags'], $_GET['type'] ) && 'page' === $_GE
 											$ftg_category_count       = 1 !== $category->count ? ' (' . $ftg_category_count_final . ')' : '';
 											$ftg_url_count            = $category->count > 1 ? '&count=' . $ftg_category_count_final . '' : '';
 
-													echo '<option ' . esc_attr( $ftg_option_selected ) . ' value="' . esc_url( get_site_url() . '?type=image&ftg-tags=' . esc_attr( $category->slug . $ftg_url_count ) ) . '">' . esc_html( $category->name ) . esc_html( $ftg_category_count ) . '</option>';
+													echo '<option ' . esc_attr( $ftg_option_selected ) . ' value="' . esc_url( get_site_url() . '/?type=image&ftg-tags=' . esc_attr( $category->slug . $ftg_url_count ) ) . '">' . esc_html( $category->name ) . esc_html( $ftg_category_count ) . '</option>';
 
 										}
 									}


### PR DESCRIPTION
= Version 1.4.5 Thursday, June 23rd, 2022 =
  * NOTE: Tested with WocCommerce Version 6.6.1
  * FIX PREMIUM: Url in tags select missing / to account for sub-site installs.