### PR TITLE
1.4.6

### DIFF
--- a/feed-them-gallery.php
+++ b/feed-them-gallery.php
@@ -7,20 +7,20 @@
  * Plugin Name: Feed Them Gallery
  * Plugin URI: https://www.slickremix.com/
  * Description: Create Beautiful Responsive Galleries in Minutes. Choose the number of columns, loadmore button, popup and more! Sell your Galleries or individual Images with WooCommerce, watermark them, zip galleries, create Albums, create Tags for Images and Galleries, search Galleries and Images with tags, and pagination in our premium version.
- * Version: 1.4.5
+ * Version: 1.4.6
  * Author: SlickRemix
  * Author URI: https://www.slickremix.com/
  * Text Domain: feed-them-gallery
  * Domain Path: /languages
  * Requires at least: WordPress 4.7.0
  * Tested up to: WordPress 6.0
- * Stable tag: 1.4.5
+ * Stable tag: 1.4.6
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * WC requires at least: 3.0.0
  * WC tested up to: 6.6.1
  *
- * @version  1.4.5
+ * @version  1.4.6
  * @package  FeedThemSocial/Core
  * @copyright   Copyright (c) 2012-2022 SlickRemix
  *
@@ -28,7 +28,7 @@
  */
 
 // Doing this to ensure any js or css changes are reloaded properly. Added to enqueued css and js files throughout.
-define( 'FTG_CURRENT_VERSION', '1.4.5' );
+define( 'FTG_CURRENT_VERSION', '1.4.6' );
 
 if ( ! defined( 'FTG_PLUGIN_FILE' ) )	{
 	define( 'FTG_PLUGIN_FILE', __FILE__ );

--- a/includes/display-gallery/display-gallery-class.php
+++ b/includes/display-gallery/display-gallery-class.php
@@ -1707,8 +1707,8 @@ class Display_Gallery {
 					if ( is_plugin_active( 'feed-them-gallery-premium/feed-them-gallery-premium.php' ) ) {
 						$gallery_to_woo       = new Gallery_to_Woocommerce();
 						$siteurl              = get_option( 'siteurl' );
-						$purchase_link        = ftg_get_option( 'woo_add_to_cart' );
-						$purchase_link_option = isset( $purchase_link['ft_gallery_woo_options'] ) ? $purchase_link['ft_gallery_woo_options'] : '';
+						$cart_option          = ftg_get_option( 'woo_add_to_cart' );
+						$purchase_link_option = isset( $cart_option ) ? $cart_option : '';
 					}
 
 					// Make sure it's not ajaxing.
@@ -2258,7 +2258,6 @@ class Display_Gallery {
 									$product_type = \WC_Product_Factory::get_product_type($product_id);
 
 									if ( 'variable' === $product_type && 'prod_page' !== $purchase_link_option ) {
-
 										$purchase_link = '' . $siteurl . '/' . $ft_gallery_cart_page_name;
 									} else {
 										if ( 'prod_page' === $purchase_link_option ) {

--- a/includes/galleries/gallery-class.php
+++ b/includes/galleries/gallery-class.php
@@ -2165,7 +2165,7 @@ class Gallery {
 		wp_update_attachment_metadata( $attach_id, $attach_data );
 
 		// Use File & Title renaming
-		if ( ftg_get_option( 'use_attachment_naming' ) ) {
+		if ( ftg_get_option( 'use_attachment_naming' ) && ftg_get_option( 'file_naming' ) ) {
 			$file_name = preg_replace( '/\.[^.]+$/', '', basename( $status['url'] ) );
 			$this->ft_gallery_rename_attachment( $post_id, $attach_id, $file_name );
 			$this->ft_gallery_generate_new_attachment_name( $post_id, $attach_id, $file_name );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: slickremix, slickchris, mikeyhoward1977
 Tags: gallery, image gallery, photo gallery, responsive gallery, wordpress gallery plugin
 Requires at least: 4.5.0
 Tested up to: 6.0
-Stable tag: 1.4.5
+Stable tag: 1.4.6
 License: GPLv2 or later
 
 Photo Gallery creation made easy. Sell images with Auto Create Product feature for WooCommerce. Watermarking, Lightbox Popup, ZIP'ing, Tags and more!
@@ -185,6 +185,10 @@ You can [register to translate the site here](http://translate.slickremix.com/wp
   * Extract the zip file and drop the contents in the wp-content/plugins/ directory of your WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
+= Version 1.4.6 Monday, July 11th, 2022 =
+  * FIX: Add default option for Title Renaming to fix image duplicate name problem.
+  * FIX PREMIUM: WooCommerce Add to Cart options not linking correctly.
+  
 = Version 1.4.5 Thursday, June 23rd, 2022 =
   * NOTE: Tested with WocCommerce Version 6.6.1
   * FIX PREMIUM: Url in tags select missing / to account for sub-site installs.


### PR DESCRIPTION
= Version 1.4.6 Monday, July 11th, 2022 =
  * FIX: Add default option for Title Renaming to fix image duplicate name problem.
  * FIX PREMIUM: WooCommerce Add to Cart options not linking correctly.